### PR TITLE
Add COST attribute to dsl

### DIFF
--- a/src/DSL/Grammar.ts
+++ b/src/DSL/Grammar.ts
@@ -15,13 +15,16 @@ export const attributes = [
   "RARITY",
   "CARD_TYPE",
   "COPIES",
+  "COST",
 ];
 export const operators = ["IN", "IS"];
 export const not = ["NOT"];
 export const hsValues = [
-    ...Object.keys(Expansions),
+  ...Object.keys(Expansions),
   ...Object.values(HsClasses),
   ...Object.values(CardRarities),
   ...Object.values(CardTypes),
-  "STANDARD"
+  "STANDARD",
+  "ODD",
+  "EVEN",
 ];

--- a/src/DSL/RuleGenerator.spec.ts
+++ b/src/DSL/RuleGenerator.spec.ts
@@ -474,6 +474,66 @@ describe("Rule Generator", () => {
           return !(costs.includes(card.cost) || !(card.cost & 1));
         },
       ],
+      [
+        "Less than with IS operator",
+        "RULE COST IS <5",
+        (card: Card, _: number) => {
+          return card.cost < 5;
+        },
+      ],
+      [
+        "Less than with IS NOT operator",
+        "RULE COST IS NOT <5",
+        (card: Card, _: number) => {
+          return card.cost >= 5;
+        },
+      ],
+      [
+        "Less than with IN operator",
+        "RULE COST IN <3, 7, 8",
+        (card: Card, _: number) => {
+          const costs: number[] = [7, 8];
+          return costs.includes(card.cost) || card.cost < 3;
+        },
+      ],
+      [
+        "Less than with NOT IN operator",
+        "RULE COST NOT IN <3, 7, 8",
+        (card: Card, _: number) => {
+          const costs: number[] = [7, 8];
+          return !(costs.includes(card.cost) || card.cost < 3);
+        },
+      ],
+      [
+        "More than with IS operator",
+        "RULE COST IS >5",
+        (card: Card, _: number) => {
+          return card.cost > 5;
+        },
+      ],
+      [
+        "More than with IS NOT operator",
+        "RULE COST IS NOT >5",
+        (card: Card, _: number) => {
+          return card.cost <= 5;
+        },
+      ],
+      [
+        "More than with IN operator",
+        "RULE COST IN >5, 1, 2",
+        (card: Card, _: number) => {
+          const costs: number[] = [1, 2];
+          return costs.includes(card.cost) || card.cost > 5;
+        },
+      ],
+      [
+        "More than with NOT IN operator",
+        "RULE COST NOT IN >5, 1, 2",
+        (card: Card, _: number) => {
+          const costs: number[] = [1, 2];
+          return !(costs.includes(card.cost) || card.cost > 5);
+        },
+      ],
     ])("should generate RULE with %o", (_, input, expectedRule) => {
       const result = generateRules(input);
 

--- a/src/DSL/RuleGenerator.spec.ts
+++ b/src/DSL/RuleGenerator.spec.ts
@@ -25,7 +25,7 @@ describe("Rule Generator", () => {
 
   describe("COPIES", () => {
     it("should generate Highlander Rule", () => {
-      const highlanderRule: Rule = (_: Card, copies: number, __: HsClass) => {
+      const highlanderRule: Rule = (_: Card, copies: number) => {
         return copies === 1;
       };
 
@@ -45,7 +45,7 @@ describe("Rule Generator", () => {
     });
 
     it("should generate Rule with IS NOT operator", () => {
-      const highlanderRule: Rule = (_: Card, copies: number, __: HsClass) => {
+      const highlanderRule: Rule = (_: Card, copies: number) => {
         return copies === 1;
       };
 
@@ -70,21 +70,21 @@ describe("Rule Generator", () => {
       [
         "IS operator",
         "RULE EXPANSION IS SHOWDOWN_BADLANDS",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.set === Expansions.SHOWDOWN_BADLANDS;
         },
       ],
       [
         "IS NOT operator",
         "RULE EXPANSION IS NOT SHOWDOWN_BADLANDS",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.set !== Expansions.SHOWDOWN_BADLANDS;
         },
       ],
       [
         "IN operator",
         "RULE EXPANSION IN SHOWDOWN_BADLANDS, CORE, WHIZBANGS_WORKSHOP",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const expansions: Expansion[] = [
             Expansions.SHOWDOWN_BADLANDS,
             Expansions.CORE,
@@ -97,7 +97,7 @@ describe("Rule Generator", () => {
       [
         "NOT IN operator",
         "RULE EXPANSION NOT IN SHOWDOWN_BADLANDS, CORE, WHIZBANGS_WORKSHOP",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const expansions: Expansion[] = [
             Expansions.SHOWDOWN_BADLANDS,
             Expansions.CORE,
@@ -110,21 +110,21 @@ describe("Rule Generator", () => {
       [
         "STANDARD value with IS operator",
         "RULE EXPANSION IS STANDARD",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return STANDARD_EXPANSIONS.includes(card.set);
         },
       ],
       [
         "STANDARD value with IS NOT operator",
         "RULE EXPANSION IS NOT STANDARD",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return !STANDARD_EXPANSIONS.includes(card.set);
         },
       ],
       [
         "STANDARD value with IN operator",
         "RULE EXPANSION IN STANDARD, THE_SUNKEN_CITY",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const expansions = [
             ...STANDARD_EXPANSIONS,
             Expansions.THE_SUNKEN_CITY,
@@ -135,7 +135,7 @@ describe("Rule Generator", () => {
       [
         "STANDARD value with IN operator with standard in later position",
         "RULE EXPANSION IN THE_SUNKEN_CITY, STANDARD",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const expansions = [
             ...STANDARD_EXPANSIONS,
             Expansions.THE_SUNKEN_CITY,
@@ -146,7 +146,7 @@ describe("Rule Generator", () => {
       [
         "STANDARD value with NOT IN operator",
         "RULE EXPANSION NOT IN STANDARD, THE_SUNKEN_CITY",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const expansions = [
             ...STANDARD_EXPANSIONS,
             Expansions.THE_SUNKEN_CITY,
@@ -157,7 +157,7 @@ describe("Rule Generator", () => {
       [
         "STANDARD value with NOT IN operator with standard in later position",
         "RULE EXPANSION NOT IN THE_SUNKEN_CITY, STANDARD",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const expansions = [
             ...STANDARD_EXPANSIONS,
             Expansions.THE_SUNKEN_CITY,
@@ -187,21 +187,21 @@ describe("Rule Generator", () => {
       [
         "IS operator",
         "RULE CLASS IS NEUTRAL",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.cardClass === HsClasses.NEUTRAL;
         },
       ],
       [
         "IS NOT operator",
         "RULE CLASS IS NOT NEUTRAL",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.cardClass !== HsClasses.NEUTRAL;
         },
       ],
       [
         "IN operator",
         "RULE CLASS IN NEUTRAL, WARRIOR, HUNTER",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const classes: HsClass[] = [
             HsClasses.NEUTRAL,
             HsClasses.WARRIOR,
@@ -215,7 +215,7 @@ describe("Rule Generator", () => {
       [
         "NOT IN operator",
         "RULE CLASS NOT IN NEUTRAL, HUNTER, WARRIOR",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const classes: HsClass[] = [
             HsClasses.NEUTRAL,
             HsClasses.WARRIOR,
@@ -249,21 +249,21 @@ describe("Rule Generator", () => {
       [
         "IS operator",
         "RULE RARITY IS COMMON",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.rarity === CardRarities.COMMON;
         },
       ],
       [
         "IS NOT operator",
         "RULE RARITY IS NOT COMMON",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.rarity !== CardRarities.COMMON;
         },
       ],
       [
         "IN operator",
         "RULE RARITY IN COMMON, LEGENDARY",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const rarities: CardRarity[] = [
             CardRarities.COMMON,
             CardRarities.LEGENDARY,
@@ -275,7 +275,7 @@ describe("Rule Generator", () => {
       [
         "NOT IN operator",
         "RULE RARITY NOT IN COMMON, LEGENDARY",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const rarities: CardRarity[] = [
             CardRarities.COMMON,
             CardRarities.LEGENDARY,
@@ -305,21 +305,21 @@ describe("Rule Generator", () => {
       [
         "IS operator",
         "RULE CARD_TYPE IS MINION",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.type === CardTypes.MINION;
         },
       ],
       [
         "IS NOT operator",
         "RULE CARD_TYPE IS NOT MINION",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           return card.type !== CardTypes.MINION;
         },
       ],
       [
         "IN operator",
         "RULE CARD_TYPE IN MINION, SPELL",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const cardTypes: CardType[] = [CardTypes.MINION, CardTypes.SPELL];
 
           return cardTypes.includes(card.type);
@@ -328,9 +328,150 @@ describe("Rule Generator", () => {
       [
         "NOT IN operator",
         "RULE CARD_TYPE NOT IN MINION, SPELL",
-        (card: Card, _: number, __: HsClass) => {
+        (card: Card, _: number) => {
           const cardTypes: CardType[] = [CardTypes.MINION, CardTypes.SPELL];
           return !cardTypes.includes(card.type);
+        },
+      ],
+    ])("should generate RULE with %o", (_, input, expectedRule) => {
+      const result = generateRules(input);
+
+      expect(validateDeckString(highlanderWarrior, result)).toEqual(
+        validateDeckString(highlanderWarrior, [expectedRule])
+      );
+
+      expect(validateDeckString(handbuffPala, result)).toEqual(
+        validateDeckString(handbuffPala, [expectedRule])
+      );
+
+      expect(validateDeckString(wildEggHunter, result)).toEqual(
+        validateDeckString(wildEggHunter, [expectedRule])
+      );
+    });
+  });
+
+  describe("COST", () => {
+    it.each([
+      [
+        "IS operator",
+        "RULE COST IS 1",
+        (card: Card, _: number) => {
+          return card.cost === 1;
+        },
+      ],
+      [
+        "IS NOT operator",
+        "RULE COST IS NOT 1",
+        (card: Card, _: number) => {
+          return card.cost !== 1;
+        },
+      ],
+      [
+        "IN operator",
+        "RULE COST IN 1, 2, 3, 4",
+        (card: Card, _: number) => {
+          const costs: number[] = [1, 2, 3, 4];
+          return costs.includes(card.cost);
+        },
+      ],
+      [
+        "NOT IN operator",
+        "RULE COST NOT IN 1, 2, 3, 4",
+        (card: Card, _: number) => {
+          const costs: number[] = [1, 2, 3, 4];
+          return !costs.includes(card.cost);
+        },
+      ],
+      [
+        "ODD value with IS operator",
+        "RULE COST IS ODD",
+        (card: Card, _: number) => {
+          return !!(card.cost & 1);
+        },
+      ],
+      [
+        "ODD value with IS NOT operator",
+        "RULE COST IS NOT ODD",
+        (card: Card, _: number) => {
+          return !(card.cost & 1);
+        },
+      ],
+      [
+        "ODD value with IN operator",
+        "RULE COST IN ODD, 2, 4",
+        (card: Card, _: number) => {
+          const costs = [2, 4];
+          return costs.includes(card.cost) || !!(card.cost & 1);
+        },
+      ],
+      [
+        "ODD value with IN operator with ODD in later position",
+        "RULE COST IN 2, 4, ODD",
+        (card: Card, _: number) => {
+          const costs = [2, 4];
+          return costs.includes(card.cost) || !!(card.cost & 1);
+        },
+      ],
+      [
+        "ODD value with NOT IN operator",
+        "RULE COST NOT IN ODD, 4",
+        (card: Card, _: number) => {
+          const costs = [4];
+          return !(costs.includes(card.cost) || !!(card.cost & 1));
+        },
+      ],
+      [
+        "ODD value with NOT IN operator with standard in later position",
+        "RULE COST NOT IN 4, 6, ODD",
+        (card: Card, _: number) => {
+          const costs = [4, 6];
+          return !(costs.includes(card.cost) || !!(card.cost & 1));
+        },
+      ],
+      [
+        "EVEN value with IS operator",
+        "RULE COST IS EVEN",
+        (card: Card, _: number) => {
+          return !(card.cost & 1);
+        },
+      ],
+      [
+        "EVEN value with IS NOT operator",
+        "RULE COST IS NOT EVEN",
+        (card: Card, _: number) => {
+          return !!(card.cost & 1);
+        },
+      ],
+      [
+        "EVEN value with IN operator",
+        "RULE COST IN EVEN, 3, 5",
+        (card: Card, _: number) => {
+          const costs = [3, 5];
+          return costs.includes(card.cost) || !(card.cost & 1);
+        },
+      ],
+      [
+        "EVEN value with IN operator with EVEN in later position",
+        "RULE COST IN 3, 5 EVEN",
+        (card: Card, _: number) => {
+          const costs = [3, 5];
+          return costs.includes(card.cost) || !(card.cost & 1);
+        },
+      ],
+      [
+        "EVEN value with NOT IN operator",
+        "RULE COST NOT IN EVEN, 3",
+        (card: Card, _: number) => {
+          const costs = [3];
+          return !(costs.includes(card.cost) || !(card.cost & 1));
+        },
+      ],
+      [
+        "EVEN value with NOT IN operator with standard in later position",
+        "RULE COST NOT IN 3, 5, EVEN",
+        (card: Card, _: number) => {
+          const costs = [3, 5];
+          return !(costs.includes(card.cost) || !(card.cost & 1));
         },
       ],
     ])("should generate RULE with %o", (_, input, expectedRule) => {

--- a/src/DSL/RuleGenerator.ts
+++ b/src/DSL/RuleGenerator.ts
@@ -20,19 +20,19 @@ export const generateRules = (input: string): Rule[] => {
   ): Rule => {
     switch (operator) {
       case "IS":
-        return (card: Card, _: number, __: HsClass) => {
+        return (card: Card, _: number) => {
           return checkAttribute(card, attribute, values[0]);
         };
       case "IS NOT":
-        return (card: Card, _: number, __: HsClass) => {
+        return (card: Card, _: number) => {
           return !checkAttribute(card, attribute, values[0]);
         };
       case "IN":
-        return (card: Card, _: number, __: HsClass) => {
+        return (card: Card, _: number) => {
           return values.some((value) => checkAttribute(card, attribute, value));
         };
       case "NOT IN":
-        return (card: Card, _: number, __: HsClass) => {
+        return (card: Card, _: number) => {
           return !values.some((value) =>
             checkAttribute(card, attribute, value)
           );
@@ -42,7 +42,11 @@ export const generateRules = (input: string): Rule[] => {
     }
   };
 
-  const checkAttribute = (card: Card, attribute: string, value: string) => {
+  const checkAttribute = (
+    card: Card,
+    attribute: string,
+    value: string
+  ): boolean => {
     switch (attribute) {
       case "EXPANSION":
         if (value === "STANDARD") {
@@ -57,6 +61,15 @@ export const generateRules = (input: string): Rule[] => {
         return card.rarity === value;
       case "CARD_TYPE":
         return card.type === value;
+      case "COST":
+        if (value === "ODD") {
+          return !!(card.cost & 1);
+        }
+        if (value === "EVEN") {
+          return !(card.cost & 1);
+        }
+        return card.cost === Number(value);
+
       default:
         throw new Error("Invalid attribute");
     }
@@ -81,13 +94,9 @@ export const generateRules = (input: string): Rule[] => {
 
     if (attribute === "COPIES") {
       if (operator === "IS") {
-        rules.push(
-          (_: Card, copies: number, __: HsClass) => copies === Number(values[0])
-        );
+        rules.push((_: Card, copies: number) => copies === Number(values[0]));
       } else {
-        rules.push(
-          (_: Card, copies: number, __: HsClass) => copies !== Number(values[0])
-        );
+        rules.push((_: Card, copies: number) => copies !== Number(values[0]));
       }
     } else {
       rules.push(createSimpleRule(attribute, operator, values));

--- a/src/DSL/RuleGenerator.ts
+++ b/src/DSL/RuleGenerator.ts
@@ -68,6 +68,13 @@ export const generateRules = (input: string): Rule[] => {
         if (value === "EVEN") {
           return !(card.cost & 1);
         }
+        if (value.startsWith(">")) {
+          return card.cost > Number(value.slice(1));
+        }
+        if (value.startsWith("<")) {
+          return card.cost < Number(value.slice(1));
+        }
+
         return card.cost === Number(value);
 
       default:

--- a/src/DSL/RuleValidator.spec.ts
+++ b/src/DSL/RuleValidator.spec.ts
@@ -35,6 +35,11 @@ describe("Rule Validator", () => {
       ],
       ["STANDARD expansion", "RULE EXPANSION IS STANDARD"],
       ["COPIES attribute with number", "RULE COPIES IS 1"],
+      ["COST attribute with number", "RULE COST IS 3"],
+      ["COST EVEN", "RULE COST IS EVEN"],
+      ["COST ODD", "RULE COST IS ODD"],
+      // ["COST LESS THAN", "RULE COST IS <5"],
+      // ["COST MORE THAN", "RULE COST IS >3"],
     ])("should return an empty array for valid inputs for %o", (_, input) => {
       const result = validateInput(input);
       expect(result).toEqual([]);
@@ -264,6 +269,13 @@ describe("Rule Validator", () => {
         "RULE CARD_TYPE IN HERO, MINION, PALADIN",
         "PALADIN",
         "card type",
+      ],
+      ["COST and a class (PALADIN)", "RULE COST IS PALADIN", "PALADIN", "cost"],
+      [
+        "COST and a class (PALADIN) in the middle of the IN values",
+        "RULE COST IN EVEN, 1, 3, PALADIN",
+        "PALADIN",
+        "cost",
       ],
     ])(
       "should return error when attribute and hsValue does not match: %o",

--- a/src/DSL/RuleValidator.spec.ts
+++ b/src/DSL/RuleValidator.spec.ts
@@ -38,8 +38,8 @@ describe("Rule Validator", () => {
       ["COST attribute with number", "RULE COST IS 3"],
       ["COST EVEN", "RULE COST IS EVEN"],
       ["COST ODD", "RULE COST IS ODD"],
-      // ["COST LESS THAN", "RULE COST IS <5"],
-      // ["COST MORE THAN", "RULE COST IS >3"],
+      ["COST LESS THAN", "RULE COST IS <5"],
+      ["COST MORE THAN", "RULE COST IS >3"],
     ])("should return an empty array for valid inputs for %o", (_, input) => {
       const result = validateInput(input);
       expect(result).toEqual([]);

--- a/src/DSL/RuleValidator.ts
+++ b/src/DSL/RuleValidator.ts
@@ -257,9 +257,23 @@ const validateSemantics = (
       }
     case "COST":
       if (words[2] === "IS") {
-        return validateSingleValue(words, index, line, ["EVEN", "ODD"], "cost", true);
+        return validateSingleValue(
+          words,
+          index,
+          line,
+          ["EVEN", "ODD"],
+          "cost",
+          true
+        );
       } else {
-        return validateValues(words, index, line, ["EVEN", "ODD"], "cost", true);
+        return validateValues(
+          words,
+          index,
+          line,
+          ["EVEN", "ODD"],
+          "cost",
+          true
+        );
       }
     default:
       return null;
@@ -282,8 +296,17 @@ const validateValues = (
   values.forEach((word, i) => {
     if (error) return;
     word = word.replace(",", "");
-    if (isNumeric(word) && acceptNumericValues) {
-      return null;
+    if (acceptNumericValues) {
+      if (isNumeric(word)) {
+        return null;
+      }
+
+      if (word.startsWith("<") || word.startsWith(">")) {
+        const num = word.slice(1);
+        if (isNumeric(num)) {
+          return null;
+        }
+      }
     }
     if (!validValues.includes(word)) {
       error = createMarker(
@@ -312,8 +335,17 @@ const validateSingleValue = (
     // the sentence was not finished
     return null;
   }
-  if (isNumeric(value) && acceptNumericValues) {
-    return null;
+  if (acceptNumericValues) {
+    if (isNumeric(value)) {
+      return null;
+    }
+
+    if (value.startsWith("<") || value.startsWith(">")) {
+      const num = value.slice(1);
+      if (isNumeric(num)) {
+        return null;
+      }
+    }
   }
   if (!validValues.includes(value)) {
     return createMarker(
@@ -342,5 +374,5 @@ const createMarker = (
 });
 
 const isNumeric = (str: string): boolean => {
-  return !isNaN(str as unknown as number);
+  return !isNaN(str as unknown as number) && !isNaN(parseFloat(str));
 };

--- a/src/DeckValidator.ts
+++ b/src/DeckValidator.ts
@@ -1,8 +1,8 @@
 import { decode } from "deckstrings";
 import cards from "./resources/cards.collectible.json"; // https://api.hearthstonejson.com/v1/latest/enUS/cards.collectible.json
-import { Card, HsClass, heroIdToClass } from "./Card";
+import { Card } from "./Card";
 
-export type Rule = (card: Card, copies: number, deckClass: HsClass) => boolean;
+export type Rule = (card: Card, copies: number) => boolean;
 
 export type CardAndCopies = {
   cardObject: Card;
@@ -20,8 +20,6 @@ export const validateDeckString = (
 
   deck = decode(deckString);
 
-  const deckClass = heroIdToClass(deck.heroes[0]);
-
   const deckCards = deck.cards.map(([id, copies]) => {
     const cardObject: Card = cards.find((c) => c.dbfId === id);
     return { cardObject, copies };
@@ -33,7 +31,7 @@ export const validateDeckString = (
 
   rules.forEach((rule) => {
     const invalidedByRule = deckCards.filter(
-      ({ cardObject, copies }) => !rule(cardObject, copies, deckClass)
+      ({ cardObject, copies }) => !rule(cardObject, copies)
     );
     invalidedByRule.forEach((c) => invalidCards.add(c));
   });


### PR DESCRIPTION
### What is the goal of this PR?

Add COST attribute to the Custom Hearthstone Rule Language. It accepts numbers and `ODD` and `EVEN`. 

**Note:** It also removes unnecessary hsClass from Rule type definition